### PR TITLE
Fix: traverse the `CommentTree` well

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@ done with DALL-E 2.
 
 # Usage
 
+## Conda environment
+
+Create or use a `conda` environment using the `environment.yml` file:
+
+```bash
+# create
+conda env create -f environment.yml
+
+# use
+conda activate dalle2-scraper
+```
+
+## Environment variables
+
 Create (and fill) the `.env` file based on the `.envdefault` file at the
 root of the repository. Then, execute the extraction script:
 

--- a/extractor/subreddit_crawler.py
+++ b/extractor/subreddit_crawler.py
@@ -1,6 +1,7 @@
 """
 Implementation of the `crawler` abstraction using Algolia.
 """
+import logging
 import re
 
 from .crawler import Crawler
@@ -19,33 +20,38 @@ class SubredditCrawler(Crawler):
         )
         self._subreddit = self._reddit_client.subreddit(subreddit)
 
-
     def crawl(self):
         openai_ids = set()
 
         # Crawl OpenAI DALL-E links from dalle2 subreddit
-        # Finds the submissions from the last hour
+        # See: https://praw.readthedocs.io/en/stable/code_overview/models/subreddit.html#praw.models.Subreddit.search
         for submission in self._subreddit.search("*", sort="new", time_filter="day"):
             openai_links = set()
 
             url = submission.url
-            permalink = submission.permalink
-            comments = submission.comments.list()
-
-            if "labs.openai" in url:
+            if "labs.openai.com/s" in url:
                 openai_links.add(url)
 
-            for comment in comments:
-                links = [
-                    link
-                    for link in re.findall(r"(https?://[^\s]+)", comment.body)
-                    if "labs.openai.com" in link
-                ]
-                for link in links:
+            comments = submission.comments.list()
+            # Traverse the Comment Tree so that the list contains only `Comment`
+            # instances.  Use `limit = None` so that all the `MoreComment` instances
+            # are processed.
+            comments.replace_more(limit=None)
+            comments_with_links = [c for c in comments if "labs.openai.com/s" in c.body]
+            for comment in comments_with_links:
+                for link in re.findall(r"(https?://[^\s]+)", comment.body):
                     openai_links.add(link)
 
+            # Parse the IDs from the links
             for link in openai_links:
-                openai_id = re.findall(r"s\/(\w+)", link)[0]
-                openai_ids.add(openai_id)
+                try:
+                    openai_id = re.findall(r"s\/(\w+)", link)[0]
+                except Exception as e:
+                    logging.error(
+                        f"ERROR: could not parse link: {link}\nError type: {e}"
+                    )
+                    continue
+                else:
+                    openai_ids.add(openai_id)
 
         return list(openai_ids)


### PR DESCRIPTION
# Summary

Sometimes you would find instances of `MoreComment` in the comment iterable.

Luckily, we can use the built-in PRAW method of `replace_more` and that would be it :-)

ezpz

I also added a try..except clause in the regex parsing part of the code so that, in case of errors, the parsing keeps going[^1].


---

[^1]: https://cushychicken.github.io/rules-for-web-scrapers/
